### PR TITLE
Qualify access to TrackedReal and TrackedArray in nonlinear.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImplicitAD"
 uuid = "e7cbb90b-9b31-4eb2-a8c8-45099c074ee1"
 authors = ["Andrew Ning <aning@byu.edu> and contributors"]
-version = "0.3"
+version = "0.3.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/external.jl
+++ b/src/external.jl
@@ -196,5 +196,5 @@ function ChainRulesCore.rrule(::typeof(_provide_rule), func, x, p, mode, jacobia
     return y, pullback
 end
 
-ReverseDiff.@grad_from_chainrules _provide_rule(func, x::TrackedArray, p, mode, jacobian, jvp, vjp)
-ReverseDiff.@grad_from_chainrules _provide_rule(func, x::AbstractArray{<:TrackedReal}, p, mode, jacobian, jvp, vjp)
+ReverseDiff.@grad_from_chainrules _provide_rule(func, x::ReverseDiff.TrackedArray, p, mode, jacobian, jvp, vjp)
+ReverseDiff.@grad_from_chainrules _provide_rule(func, x::AbstractArray{<:ReverseDiff.TrackedReal}, p, mode, jacobian, jvp, vjp)

--- a/src/linear.jl
+++ b/src/linear.jl
@@ -199,9 +199,9 @@ function ChainRulesCore.rrule(::typeof(_implicit_linear), A, b, lsolve, Af)
 end
 
 # register above rule for ReverseDiff
-ReverseDiff.@grad_from_chainrules _implicit_linear(A::Union{TrackedArray, AbstractArray{<:TrackedReal}}, b, lsolve, Af)
-ReverseDiff.@grad_from_chainrules _implicit_linear(A, b::Union{TrackedArray, AbstractArray{<:TrackedReal}}, lsolve, Af)
-ReverseDiff.@grad_from_chainrules _implicit_linear(A::Union{TrackedArray, AbstractArray{<:TrackedReal}}, b::Union{TrackedArray, AbstractVector{<:TrackedReal}}, lsolve, Af)
+ReverseDiff.@grad_from_chainrules _implicit_linear(A::Union{ReverseDiff.TrackedArray, AbstractArray{<:ReverseDiff.TrackedReal}}, b, lsolve, Af)
+ReverseDiff.@grad_from_chainrules _implicit_linear(A, b::Union{ReverseDiff.TrackedArray, AbstractArray{<:ReverseDiff.TrackedReal}}, lsolve, Af)
+ReverseDiff.@grad_from_chainrules _implicit_linear(A::Union{ReverseDiff.TrackedArray, AbstractArray{<:ReverseDiff.TrackedReal}}, b::Union{ReverseDiff.TrackedArray, AbstractVector{<:ReverseDiff.TrackedReal}}, lsolve, Af)
 
 
 # function implicit_linear_inplace(A, b, y, Af)

--- a/src/nonlinear.jl
+++ b/src/nonlinear.jl
@@ -117,5 +117,5 @@ end
 
 
 # register above rule for ReverseDiff
-ReverseDiff.@grad_from_chainrules _implicit(solve, residual, x::TrackedArray, p, drdy, lsolve)
-ReverseDiff.@grad_from_chainrules _implicit(solve, residual, x::AbstractVector{<:TrackedReal}, p, drdy, lsolve)
+ReverseDiff.@grad_from_chainrules _implicit(solve, residual, x::ReverseDiff.TrackedArray, p, drdy, lsolve)
+ReverseDiff.@grad_from_chainrules _implicit(solve, residual, x::AbstractVector{<:ReverseDiff.TrackedReal}, p, drdy, lsolve)


### PR DESCRIPTION
This PR fixes a precompile error I get when loading ImplicitAD.jl v0.3.0 on Julia 1.9.1 related to unqualified reference to ReverseDiff.TrackedReal and ReverseDiff.TrackedArray:

```
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.9.1 (2023-06-07)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

(openvsp_rotor_dev) pkg> activate --temp
  Activating new project at `/tmp/jl_yGShMe`

(jl_yGShMe) pkg> add ImplicitAD
   Resolving package versions...
    Updating `/tmp/jl_yGShMe/Project.toml`
  [e7cbb90b] + ImplicitAD v0.3.0
    Updating `/tmp/jl_yGShMe/Manifest.toml`
  [d360d2e6] + ChainRulesCore v1.16.0
  [bbf7d656] + CommonSubexpressions v0.3.0
  [34da2185] + Compat v4.7.0
  [163ba53b] + DiffResults v1.1.0
  [b552c78f] + DiffRules v1.15.1
  [ffbed154] + DocStringExtensions v0.9.3
  [f6369f11] + ForwardDiff v0.10.35
  [069b7b12] + FunctionWrappers v1.1.3
  [e7cbb90b] + ImplicitAD v0.3.0
  [92d709cd] + IrrationalConstants v0.2.2
  [692b3bcd] + JLLWrappers v1.4.1
  [2ab3a3ac] + LogExpFunctions v0.3.24
  [1914dd2f] + MacroTools v0.5.10
  [77ba4419] + NaNMath v1.0.2
  [21216c6a] + Preferences v1.4.0
  [37e2e3b7] + ReverseDiff v1.15.0
  [276daf66] + SpecialFunctions v2.3.0
  [90137ffa] + StaticArrays v1.6.1
  [1e83bf80] + StaticArraysCore v1.4.2
  [efe28fd5] + OpenSpecFun_jll v0.5.5+0
  [0dad84c5] + ArgTools v1.1.1
  [56f22d72] + Artifacts
  [2a0f44e3] + Base64
  [ade2ca70] + Dates
  [f43a241f] + Downloads v1.6.0
  [7b1f6079] + FileWatching
  [b77e0a4c] + InteractiveUtils
  [b27032c2] + LibCURL v0.6.3
  [76f85450] + LibGit2
  [8f399da3] + Libdl
  [37e2e46d] + LinearAlgebra
  [56ddb016] + Logging
  [d6f4376e] + Markdown
  [ca575930] + NetworkOptions v1.2.0
  [44cfe95a] + Pkg v1.9.0
  [de0858da] + Printf
  [3fa0cd96] + REPL
  [9a3f8284] + Random
  [ea8e919c] + SHA v0.7.0
  [9e88b42a] + Serialization
  [6462fe0b] + Sockets
  [2f01184e] + SparseArrays
  [10745b16] + Statistics v1.9.0
  [fa267f1f] + TOML v1.0.3
  [a4e569a6] + Tar v1.10.0
  [8dfed614] + Test
  [cf7118a7] + UUIDs
  [4ec0a83e] + Unicode
  [e66e0078] + CompilerSupportLibraries_jll v1.0.2+0
  [deac9b47] + LibCURL_jll v7.84.0+0
  [29816b5a] + LibSSH2_jll v1.10.2+0
  [c8ffd9c3] + MbedTLS_jll v2.28.2+0
  [14a3606d] + MozillaCACerts_jll v2022.10.11
  [4536629a] + OpenBLAS_jll v0.3.21+4
  [05823500] + OpenLibm_jll v0.8.1+0
  [bea87d4a] + SuiteSparse_jll v5.10.1+6
  [83775a58] + Zlib_jll v1.2.13+0
  [8e850b90] + libblastrampoline_jll v5.8.0+0
  [8e850ede] + nghttp2_jll v1.48.0+0
  [3f19e933] + p7zip_jll v17.4.0+0
Precompiling project...
  ✗ ImplicitAD
  0 dependencies successfully precompiled in 5 seconds. 31 already precompiled.
  1 dependency errored. To see a full report either run `import Pkg; Pkg.precompile()` or load the package

(jl_yGShMe) pkg> using ImplicitAD
ERROR: `using` is not a recognized command. Type ? for help with available commands

julia> using ImplicitAD
[ Info: Precompiling ImplicitAD [e7cbb90b-9b31-4eb2-a8c8-45099c074ee1]
ERROR: LoadError: UndefVarError: `TrackedArray` not defined
Stacktrace:
 [1] top-level scope
   @ ~/.julia/packages/ReverseDiff/7pHoq/src/macros.jl:334
 [2] include(mod::Module, _path::String)
   @ Base ./Base.jl:457
 [3] include(x::String)
   @ ImplicitAD ~/.julia/packages/ImplicitAD/dFny7/src/ImplicitAD.jl:1
 [4] top-level scope
   @ ~/.julia/packages/ImplicitAD/dFny7/src/ImplicitAD.jl:11
 [5] include
   @ ./Base.jl:457 [inlined]
 [6] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
   @ Base ./loading.jl:2045
 [7] top-level scope
   @ stdin:3
in expression starting at /home/dingraha/.julia/packages/ImplicitAD/dFny7/src/nonlinear.jl:120
in expression starting at /home/dingraha/.julia/packages/ImplicitAD/dFny7/src/ImplicitAD.jl:1
in expression starting at stdin:3
ERROR: Failed to precompile ImplicitAD [e7cbb90b-9b31-4eb2-a8c8-45099c074ee1] to "/home/dingraha/.julia/compiled/v1.9/ImplicitAD/jl_JDkKSV".
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] compilecache(pkg::Base.PkgId, path::String, internal_stderr::IO, internal_stdout::IO, keep_loaded_modules::Bool)
   @ Base ./loading.jl:2296
 [3] compilecache
   @ ./loading.jl:2163 [inlined]
 [4] _require(pkg::Base.PkgId, env::String)
   @ Base ./loading.jl:1805
 [5] _require_prelocked(uuidkey::Base.PkgId, env::String)
   @ Base ./loading.jl:1660
 [6] macro expansion
   @ ./loading.jl:1648 [inlined]
 [7] macro expansion
   @ ./lock.jl:267 [inlined]
 [8] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:1611

julia> 

```