### PR TITLE
Improve type stability in implicit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImplicitAD"
 uuid = "e7cbb90b-9b31-4eb2-a8c8-45099c074ee1"
 authors = ["Andrew Ning <aning@byu.edu> and contributors"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/external.jl
+++ b/src/external.jl
@@ -20,7 +20,7 @@ provide_rule(func, x, p=(); mode="ffd", jacobian=nothing, jvp=nothing, vjp=nothi
 
 _provide_rule(func, x, p, mode, jacobian, jvp, vjp) = func(x, p)
 
-function _provide_rule(func, x::AbstractVector{<:ForwardDiff.Dual{T}}, p, mode, jacobian, jvp, vjp) where {T}
+function _provide_rule(func, x::AbstractVector{<:ForwardDiff.Dual{T,V,N}}, p, mode, jacobian, jvp, vjp) where {T,V,N}
 
     # unpack dual
     xv, xdot = unpack_dual(x)
@@ -124,7 +124,7 @@ function _provide_rule(func, x::AbstractVector{<:ForwardDiff.Dual{T}}, p, mode, 
         error("invalid mode")
     end
 
-    return pack_dual(yv, ydot, T)
+    return pack_dual(yv, ydot, T, Val(N))
 end
 
 

--- a/src/internals.jl
+++ b/src/internals.jl
@@ -18,6 +18,20 @@ Create a ForwardDiff Dual with value yv, derivatives dy, and Dual type T
 pack_dual(yv::AbstractFloat, dy, T) = ForwardDiff.Dual{T}(yv, ForwardDiff.Partials(Tuple(dy)))
 pack_dual(yv::AbstractVector, dy, T) = ForwardDiff.Dual{T}.(yv, ForwardDiff.Partials.(Tuple.(eachrow(dy))))
 
+# type-stable versions, where the tuple size is inferrable
+
+function pack_dual(yv::AbstractFloat, dy, ::Type{T}, ::Val{N}) where {T,N}
+    dyt = NTuple{N}(dy)
+    dyp = ForwardDiff.Partials(dyt)
+    return ForwardDiff.Dual{T}(yv, dyp)
+end
+
+function pack_dual(yv::AbstractVector, dy, ::Type{T}, ::Val{N}) where {T,N}
+    dyt = NTuple{N}.(eachrow(dy))
+    dyp = ForwardDiff.Partials.(dyt)
+    return ForwardDiff.Dual{T}.(yv, dyp)
+end
+
 # -----------------------------------------
 
 """

--- a/src/linear.jl
+++ b/src/linear.jl
@@ -111,7 +111,7 @@ _implicit_linear(A::AbstractArray{<:ForwardDiff.Dual{T}}, b, lsolve, mmul, Af) w
 # implicit_linear!(ydot, A::AbstractArray{<:ForwardDiff.Dual{T}}, b, lsolve, Af) where {T} = linear_dual!(ydot, A, b, lsolve, Af, T)
 
 # Both A and b contain duals
-function linear_dual(A, b, lsolve, mmul, Af, T)
+function linear_dual(A, b, lsolve, mmul, Af, ::Type{T}) where {T}
 
     # unpack dual numbers (if not dual numbers, since only one might be, just returns itself)
     bv = fd_value(b)
@@ -231,4 +231,3 @@ ReverseDiff.@grad_from_chainrules _implicit_linear(A::Union{ReverseDiff.TrackedA
 #     # reassign y to this value
 #     y .= pack_dual(yv, ydot, T)
 # end
-

--- a/src/nonlinear.jl
+++ b/src/nonlinear.jl
@@ -79,7 +79,7 @@ _implicit(solve, residual, x, p, drdy, lsolve) = solve(x, p)
 
 # Overloaded for ForwardDiff inputs, providing exact derivatives using
 # Jacobian vector product.
-function _implicit(solve, residual, x::AbstractVector{<:ForwardDiff.Dual{T}}, p, drdy, lsolve) where {T}
+function _implicit(solve, residual::R, x::AbstractVector{<:ForwardDiff.Dual{T,V,N}}, p, drdy, lsolve) where {R,T,V,N}
 
     # evaluate solver
     xv = fd_value(x)
@@ -95,7 +95,7 @@ function _implicit(solve, residual, x::AbstractVector{<:ForwardDiff.Dual{T}}, p,
     ydot = lsolve(A, b)
 
     # repack in ForwardDiff Dual
-    return pack_dual(yv, ydot, T)
+    return pack_dual(yv, ydot, T, Val(N))
 end
 
 


### PR DESCRIPTION
Following my conversation with @Cardoza2, here's a little patch that should greatly improve type stability, and therefore performance.

The issue with your `pack_dual` function was that the resulting `Dual` numbers were not inferrable, because:

- the tag `T` was not being passed as a `Type`, which [prevented Julia from specializing](https://docs.julialang.org/en/v1/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing)
- the tuple size `N` was not inferrable because the partial derivatives were collapsed into a vector/matrix, whose size is not know statically

Here are the results of my changes, on the example from the tutorial:

```julia
using NLsolve
using ForwardDiff
using ImplicitAD
using Chairmarks

function residual!(r, y, x, p)
    r[1] = (y[1] + x[1])*(y[2]^3-x[2])+x[3]
    r[2] = sin(y[2]*exp(y[1])-1)*x[4]
end

function solve(x, p)
    rwrap(r, y) = residual!(r, y, x[1:4], p)  # closure using some of the input variables within x just as an example
    res = nlsolve(rwrap, [0.1; 1.2], autodiff=:forward)
    return res.zero
end

function modprogram(x)
    z = 2.0*x
    w = z + x.^2
    y = implicit(solve, residual!, w)
    return y[1] .+ w*y[2]
end

x = [1.0; 2.0; 3.0; 4.0; 5.0]

config = ForwardDiff.JacobianConfig(modprogram, x);
```

Benchmark before changes:

```julia
julia> @b ForwardDiff.jacobian(modprogram, x, config)
18.333 μs (245 allocs: 11.953 KiB)
```

Benchmark after changes:

```julia
julia> @b ForwardDiff.jacobian(modprogram, x, config)
7.708 μs (172 allocs: 9.188 KiB)
```
