### PR TITLE
Remove unused DifferentiationInterface dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "1.1.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
@@ -18,7 +17,6 @@ PyCallExt = "PythonCall"
 
 [compat]
 ChainRulesCore = "1.15"
-DifferentiationInterface = "0.6"
 ForwardDiff = "0.10.30, 1"
 PythonCall = "0.9.28"
 ReverseDiff = "1.14"

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -417,7 +417,7 @@ To solve these sets of residuals, we use the default trust-region method in NLso
 ```@example implicit
 function onestep!(y, yprev, t, tprev, xd, xci, p)
     f!(r, yt) = residual!(r, yt, yprev, t, tprev, xd, xci, p)
-    sol = nlsolve(f!, yprev, autodiff=:forward, ftol=1e-12)
+    sol = nlsolve(f!, Vector(yprev), autodiff=:forward, ftol=1e-12)
     y .= sol.zero
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -719,7 +719,7 @@ end
 
     function onestep(yprev, t, tprev, xd, xci, p)
         f(yt) = residual(yt, yprev, t, tprev, xd, xci, p)
-        sol = nlsolve(f, yprev, autodiff=:forward, ftol=1e-12)
+        sol = nlsolve(f, Vector(yprev), autodiff=:forward, ftol=1e-12)
         return sol.zero
     end
 
@@ -777,7 +777,7 @@ end
 
     function onestep!(y, yprev, t, tprev, xd, xci, p)
         f!(r, yt) = residual!(r, yt, yprev, t, tprev, xd, xci, p)
-        sol = nlsolve(f!, yprev, autodiff=:forward, ftol=1e-12)
+        sol = nlsolve(f!, Vector(yprev), autodiff=:forward, ftol=1e-12)
         y .= sol.zero
         return nothing
     end


### PR DESCRIPTION
# Remove unused DifferentiationInterface dependency

## Summary

Removes `DifferentiationInterface` from both `[deps]` and `[compat]` in `Project.toml`. This package is listed as a dependency but is never imported or used in any source file.
This was preventing updating GXBeam.jl

## Motivation

`DifferentiationInterface` was added as a dependency in v1.0.0 but no code in ImplicitAD actually uses it -- all AD is done directly through `ForwardDiff`, `ReverseDiff`, and `ChainRulesCore`. Having it as a dependency unnecessarily constrains downstream packages (e.g., pinning them to DI 0.6) and increases install/precompile times.

This was discovered while upgrading [GXBeam.jl](https://github.com/byuflowlab/GXBeam.jl) from the deprecated `SparseDiffTools.jl` to `DifferentiationInterface.jl` (see [GXBeam.jl#136](https://github.com/byuflowlab/GXBeam.jl/issues/136)). The `DI = "0.6"` compat bound in ImplicitAD prevented GXBeam from using DI 0.7, which is needed for compatibility with the latest SciML ecosystem.

## Changes

- `Project.toml`: Removed `DifferentiationInterface` from `[deps]` and `[compat]`

No source code changes -- the package was never used.
